### PR TITLE
Publish package to public npm repo.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,25 @@
+name: Build and test
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://npm.pkg.github.com"
+      - run: npm ci
+      - run: npm test
+
+      - name: Set package version
+        run: node ./.github/workflows/setPackageVersion.js
+        env:
+          CI_BRANCH: ${{github.ref}}
+          COMMIT_SHA: ${{github.sha}}
+
+      - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,25 +1,14 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Node.js Package
+name: Publish npm package
 
 on:
   release:
     types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm ci
-      - run: npm test
-
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +16,18 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
+          cache: "npm"
       - run: npm ci
+      - run: npm test
+
+      - name: Set package version
+        run: node ./.github/workflows/setPackageVersion.js
+        env:
+          CI_BRANCH: ${{github.ref}}
+          COMMIT_SHA: ${{github.sha}}
+
+      - run: npm run build
+
       - run: npm publish --access public
         env:
-          NPM_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NPM_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ jobs:
       - run: npm ci
       - run: npm test
 
+      # Writes the version.json file and sets a tag on the version for non-main builds.
       - name: Set package version
         run: node ./.github/workflows/setPackageVersion.js
         env:
@@ -28,6 +29,14 @@ jobs:
 
       - run: npm run build
 
+      # Publishes the package with a beta tag if this is a prerelease.
+      - run: npm publish --access public --tag beta
+        if: ${{ github.event.release.prerelease }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+
+      # Publishes the package with the latest tag if this is not a prerelease.
       - run: npm publish --access public
+        if: ${{ !github.event.release.prerelease }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/setPackageVersion.js
+++ b/.github/workflows/setPackageVersion.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+
+const packageJsonPath = './package.json';
+
+const packageJsonContent = JSON.parse(fs.readFileSync(packageJsonPath))
+
+const branch = process.env.CI_BRANCH.replace(/\/|_/g, '-').replace(/^refs-heads-/, '');
+const commitSha = process.env.COMMIT_SHA.substring(0, 7);
+const currentDate = new Date();
+const date = currentDate.toISOString().replace(/:/g, '');
+
+console.log(`branch: ${branch}`);
+console.log(`commitSha: ${commitSha}`);
+
+if(branch != 'main') {
+  // Don't add a tag if we are on main, just go with the plain version.
+  packageJsonContent.version = `${packageJsonContent.version}-${branch}-${date}-${commitSha}`;
+}
+console.log(`Package version: ${packageJsonContent.version}`);
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2), 'utf8');
+
+// Also write a version file so we can report the version to Sentry.
+const versionJsonPath = './src/version.json';
+const versionJsonContent = { version: packageJsonContent.version}
+fs.writeFileSync(versionJsonPath, JSON.stringify(versionJsonContent, null, 2), 'utf8');

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package is intended for partners of GetSetUp to include into their build pr
 At the moment this package is only available if you have been given access to GetSetUp's GitHub npm repository. After you have access and your `.npmrc` is configured appropriately you can just:
 
 ```sh
-npm i @getsetup-io/gsu-embedded-shell
+npm i @getsetup-io/embed
 ```
 
 ## Versioning
@@ -13,7 +13,7 @@ This package follows [semver](https://semver.org/).
 
 ## Quick Start Example
 ```ts
-import * as GSU from '@getsetup-io/gsu-embedded-shell'
+import * as GSU from '@getsetup-io/embed'
 
 // This function is supplied by the hosting page.
 // They should preform any checking and sanitation they wish to here.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,20 +1,23 @@
 # Setup
 
 ## CORS
+
 The GetSetUp Embedded product requires some CORS configuration by GetSetUp to allow other sites access. We have configured access for https://uat-aperture.imds.tv and http://localhost:3001. If you require access for other development urls please contact mitchell@getsetup.io.
 
 ## Site layout
+
 For the example below we will assume a two page site. The first page will host the "learn" page that embeds a list of classes offered by GetSetUp.
 The second page is the "joinClass" page that hosts the video viewing and chat experience.
 
 ## How to install locally
 
 1. Save the package to disk locally.
-2. In your project, run `npm install /path/to/package/getsetup-io-gsu-embedded-shell-1.2.0.tgz`
+2. In your project, run `npm install /path/to/package/getsetup-io-embed-1.2.0.tgz`
 
 The next step is to import and configure the package on a couple of pages.
 
 ### Browsing page
+
 First on a page where you want the class browsing experience create a div and setup the iframe:
 
 ```html
@@ -22,44 +25,50 @@ First on a page where you want the class browsing experience create a div and se
 ```
 
 ```ts
-import * as GSU from '@getsetup-io/gsu-embedded-shell'
+import * as GSU from "@getsetup-io/embed";
 
 // This function is supplied by the hosting page.
 // We assume a simple navigation scheme, and we will ignore classSlug for now.
 // This function will be called by the GSU iframe when it needs to navigate.
-const navigationCallBack = (navigationAction: GSU.NavigationAction, sessionId?: string, classSlug?: string) => {
-  let href = `/hostSitePath/${navigationAction}`
+const navigationCallBack = (
+  navigationAction: GSU.NavigationAction,
+  sessionId?: string,
+  classSlug?: string
+) => {
+  let href = `/hostSitePath/${navigationAction}`;
 
   // The 'joinClass' navigation action is special because we need to pass the sessionId to the 'joinClass' page.
-  if (navigationAction === 'joinClass' && sessionId) {
-    href = href + `?sessionId=${sessionId}`
+  if (navigationAction === "joinClass" && sessionId) {
+    href = href + `?sessionId=${sessionId}`;
   }
-  window.location.href = href
-}
+  window.location.href = href;
+};
 
 // Generate a JWE token using the key provided to you by GetSetUp.
 // The tokenRequestCallBack is not currently optional,
 // but we can return nothing if we don't need chat working.
-const tokenRequestCallBack = () => {}
+const tokenRequestCallBack = () => {};
 
 GSU.createIframe({
-  targetElementId: 'iframe-target',
-  targetPage: 'learn',
-  embeddingOrgId: 'gsudemo',
+  targetElementId: "iframe-target",
+  targetPage: "learn",
+  embeddingOrgId: "gsudemo",
   navigationCallBack,
   tokenRequestCallBack,
   // This targetUrls object isn't necessary in production integrations, but it allows us to point to the dev environment.
   targetUrls: {
-    learn: 'https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/learn',
-    fitness: 'https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/fitness',
-    joinClass: 'https://lobby-embed.gsudevelopment.com/session/{sessionId}',
+    learn: "https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/learn",
+    fitness:
+      "https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/fitness",
+    joinClass: "https://lobby-embed.gsudevelopment.com/session/{sessionId}",
   },
-})
+});
 ```
 
 The content of the div will be replaced with the GetSetUp iframe.
 
 ### Join Class page
+
 Then on a second page where you want the user to watch the class:
 
 ```html
@@ -67,45 +76,51 @@ Then on a second page where you want the user to watch the class:
 ```
 
 ```ts
-import * as GSU from '@getsetup-io/gsu-embedded-shell'
+import * as GSU from "@getsetup-io/embed";
 
 // This function is supplied by the hosting page.
 // We assume a simple navigation scheme, and we will ignore classSlug for now.
 // This function will be called by the GSU iframe when it needs to navigate.
-const navigationCallBack = (navigationAction: GSU.NavigationAction, sessionId?: string, classSlug?: string) => {
-  let href = `/hostSitePath/${navigationAction}`
+const navigationCallBack = (
+  navigationAction: GSU.NavigationAction,
+  sessionId?: string,
+  classSlug?: string
+) => {
+  let href = `/hostSitePath/${navigationAction}`;
 
   // The 'joinClass' navigation action is special because we need to pass the sessionId to the 'joinClass' page.
-  if (navigationAction === 'joinClass' && sessionId) {
-    href = href + `?sessionId=${sessionId}`
+  if (navigationAction === "joinClass" && sessionId) {
+    href = href + `?sessionId=${sessionId}`;
   }
-  window.location.href = href
-}
+  window.location.href = href;
+};
 
 // Generate a JWE token using the key provided to you by GetSetUp.
 // The tokenRequestCallBack is not currently optional,
 // but we can return nothing if we don't need chat working.
-const tokenRequestCallBack = () => {}
+const tokenRequestCallBack = () => {};
 
 //Get the sessionId from the query string.
-const urlParams = new URLSearchParams(window.location.search)
-const sessionId = urlParams.get('sessionId')
+const urlParams = new URLSearchParams(window.location.search);
+const sessionId = urlParams.get("sessionId");
 
 GSU.createIframe({
-  targetElementId: 'iframe-target',
-  targetPage: 'joinClass',
-  embeddingOrgId: 'gsudemo',
+  targetElementId: "iframe-target",
+  targetPage: "joinClass",
+  embeddingOrgId: "gsudemo",
   sessionId: sessionId,
   navigationCallBack,
   tokenRequestCallBack,
   // This targetUrls object isn't necessary in production integrations, but it allows us to point to the dev environment.
   targetUrls: {
-    learn: 'https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/learn',
-    fitness: 'https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/fitness',
-    joinClass: 'https://lobby-embed.gsudevelopment.com/session/{sessionId}',
+    learn: "https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/learn",
+    fitness:
+      "https://embed.gsudevelopment.com/embedded/{embeddingOrgId}/fitness",
+    joinClass: "https://lobby-embed.gsudevelopment.com/session/{sessionId}",
   },
-})
+});
 ```
 
 ## Use the site
+
 Now that both pages are setup, you can go to the page hosting the "learn" page and click on a class. The iframe will request that the hosting page navigates to the "joinClass" page using the `navigationCallBack` we setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@getsetup-io/gsu-embedded-shell",
+  "name": "@getsetup/embed",
   "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@getsetup-io/gsu-embedded-shell",
+      "name": "@getsetup/embed",
       "version": "1.4.0",
       "license": "UNLICENSED",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@getsetup-io/gsu-embedded-shell",
+  "name": "@getsetup/embed",
   "version": "1.4.0",
   "description": "",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/getsetup-io/gsu-web.git"
+    "url": "https://github.com/getsetup-io/embed-npm-package.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This adds the publishing pipeline for pushing the package to npmjs.com.

At the moment releases are published when a github release is created. We should automate that more, but this works for now.