### PR TITLE
Fix release tagging.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Set package version
         run: node ./.github/workflows/setPackageVersion.js
         env:
-          CI_BRANCH: ${{github.ref}}
+          REF_NAME: ${{github.ref_name}}
           COMMIT_SHA: ${{github.sha}}
+          IS_PRERELEASE: true
 
       - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,12 +20,13 @@ jobs:
       - run: npm ci
       - run: npm test
 
-      # Writes the version.json file and sets a tag on the version for non-main builds.
+      # Writes the version.json file and sets a tag on the version for prerelease builds.
       - name: Set package version
         run: node ./.github/workflows/setPackageVersion.js
         env:
-          CI_BRANCH: ${{github.ref}}
+          REF_NAME: ${{github.ref_name}}
           COMMIT_SHA: ${{github.sha}}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
 
       - run: npm run build
 

--- a/.github/workflows/setPackageVersion.js
+++ b/.github/workflows/setPackageVersion.js
@@ -2,19 +2,19 @@ const fs = require("fs");
 
 const packageJsonPath = './package.json';
 
-const packageJsonContent = JSON.parse(fs.readFileSync(packageJsonPath))
+const packageJsonContent = JSON.parse(fs.readFileSync(packageJsonPath));
 
-const branch = process.env.CI_BRANCH.replace(/\/|_/g, '-').replace(/^refs-heads-/, '');
+const gitRef = process.env.REF_NAME.replace(/\/|_/g, '-');
 const commitSha = process.env.COMMIT_SHA.substring(0, 7);
 const currentDate = new Date();
 const date = currentDate.toISOString().replace(/:/g, '');
 
-console.log(`branch: ${branch}`);
+console.log(`Git Ref: ${gitRef}`);
 console.log(`commitSha: ${commitSha}`);
 
-if(branch != 'main') {
-  // Don't add a tag if we are on main, just go with the plain version.
-  packageJsonContent.version = `${packageJsonContent.version}-${branch}-${date}-${commitSha}`;
+if (process.env.IS_PRERELEASE) {
+  // Only add a tag to the version if we are releasing a prerelease.
+  packageJsonContent.version = `${packageJsonContent.version}-${gitRef}-${date}-${commitSha}`;
 }
 console.log(`Package version: ${packageJsonContent.version}`);
 
@@ -22,5 +22,5 @@ fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonContent, null, 2), '
 
 // Also write a version file so we can report the version to Sentry.
 const versionJsonPath = './src/version.json';
-const versionJsonContent = { version: packageJsonContent.version}
+const versionJsonContent = { version: packageJsonContent.version };
 fs.writeFileSync(versionJsonPath, JSON.stringify(versionJsonContent, null, 2), 'utf8');


### PR DESCRIPTION
Currently the release process adds tags to the version for releases that it shouldn't. It does this because the `setPackageVersion` script is checking if the build is from the main branch, but GitHub releases trigger a build with a git ref of the tag, not the branch.

This fixes that script to check for the `IS_PRERELEASE` env var that is hooked up to the `github.event.release.prerelease` context variable.