### PR TITLE
EP-848: Restructure Navigation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -664,4 +664,25 @@ describe('GSU Embedded Shell', () => {
     // Once for the head request, once for the loading failed report.
     expect(global.fetch).toBeCalledTimes(2)
   })
+
+  test('sends the disableChat query string if required', () => {
+    document.body.innerHTML = '<div id="gsuTarget"></div>'
+
+    createIframe({
+      targetElementId: 'gsuTarget',
+      targetPage: 'fitness',
+      navigationCallBack: mockNavCallback,
+      embeddingOrgId: 'AOL',
+      tokenRequestCallBack: mockTokenCallback,
+      disableChat: true,
+    })
+
+    const gsuTargetChildren = queryByAttribute('id', document.body, 'gsuTarget')?.children
+    expect(gsuTargetChildren).not.toBeNull()
+    expect(gsuTargetChildren).not.toBeUndefined()
+    expect(gsuTargetChildren!.length).toBe(1)
+
+    const gsuIframe = gsuTargetChildren![0]
+    expect(gsuIframe).toHaveAttribute('src', expect.stringContaining('disable-chat=true'))
+  })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -665,7 +665,7 @@ describe('GSU Embedded Shell', () => {
     expect(global.fetch).toBeCalledTimes(2)
   })
 
-  test('sends the disableChat query string if required', () => {
+  test('sends the disableChat query string if disableChat option is set', () => {
     document.body.innerHTML = '<div id="gsuTarget"></div>'
 
     createIframe({
@@ -675,6 +675,12 @@ describe('GSU Embedded Shell', () => {
       embeddingOrgId: 'AOL',
       tokenRequestCallBack: mockTokenCallback,
       disableChat: true,
+      navigationCallBacks: {
+        joinClass: () => {},
+        learn: () => {},
+        fitness: () => {},
+        login: () => {},
+      },
     })
 
     const gsuTargetChildren = queryByAttribute('id', document.body, 'gsuTarget')?.children
@@ -684,5 +690,51 @@ describe('GSU Embedded Shell', () => {
 
     const gsuIframe = gsuTargetChildren![0]
     expect(gsuIframe).toHaveAttribute('src', expect.stringContaining('disable-chat=true'))
+  })
+
+  test('sends the disableChat query string if login navigation function is not provided', () => {
+    document.body.innerHTML = '<div id="gsuTarget"></div>'
+
+    createIframe({
+      targetElementId: 'gsuTarget',
+      targetPage: 'fitness',
+      navigationCallBack: mockNavCallback,
+      embeddingOrgId: 'AOL',
+      tokenRequestCallBack: mockTokenCallback,
+    })
+
+    const gsuTargetChildren = queryByAttribute('id', document.body, 'gsuTarget')?.children
+    expect(gsuTargetChildren).not.toBeNull()
+    expect(gsuTargetChildren).not.toBeUndefined()
+    expect(gsuTargetChildren!.length).toBe(1)
+
+    const gsuIframe = gsuTargetChildren![0]
+    expect(gsuIframe).toHaveAttribute('src', expect.stringContaining('disable-chat=true'))
+  })
+
+  test('does not send the disableChat query string if login navigation function is provided', () => {
+    document.body.innerHTML = '<div id="gsuTarget"></div>'
+
+    createIframe({
+      targetElementId: 'gsuTarget',
+      targetPage: 'fitness',
+      navigationCallBack: mockNavCallback,
+      embeddingOrgId: 'AOL',
+      tokenRequestCallBack: mockTokenCallback,
+      navigationCallBacks: {
+        joinClass: () => {},
+        learn: () => {},
+        fitness: () => {},
+        login: () => {},
+      },
+    })
+
+    const gsuTargetChildren = queryByAttribute('id', document.body, 'gsuTarget')?.children
+    expect(gsuTargetChildren).not.toBeNull()
+    expect(gsuTargetChildren).not.toBeUndefined()
+    expect(gsuTargetChildren!.length).toBe(1)
+
+    const gsuIframe = gsuTargetChildren![0]
+    expect(gsuIframe).toHaveAttribute('src', expect.not.stringContaining('disable-chat=true'))
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ export function createIframe({
   const iframeSrc = new URL(targetPages[targetPage])
   iframeSrc.searchParams.append('embedding-org-id', normalisedOrgId)
   if (deviceId) iframeSrc.searchParams.append('device-id', deviceId)
-  if (disableChat) iframeSrc.searchParams.append('disable-chat', 'true')
+  if (disableChat || !navigationCallBacks?.login) iframeSrc.searchParams.append('disable-chat', 'true')
 
   // Pass the join class link template to allow the page to construct hosting site links for SEO.
   if (linkTemplates?.joinClass) iframeSrc.searchParams.append('link-template-join-class', linkTemplates?.joinClass)

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,12 +54,12 @@ export interface NavigationCallBacks {
   fitness: () => void
   /**
    * This function is called when the user has clicked the help button in the iframe.
-   * The hoisting site could navigate to a help page, or show a modal, or whatever is appropriate.
+   * The hosting site could navigate to a help page, or show a modal, or whatever is appropriate.
    */
   help?: () => void
   /**
    * This function is called when the user wants to login to the chat provided in the joinClass page.
-   * The hoisting site should log the user in and return them to the current page.
+   * The hosting site should log the user in and return them to the current page.
    * If this function is not supplied then chat functionally will be disabled.
    */
   login?: () => void


### PR DESCRIPTION
**What:**
This deprecates the `navigationCallBack` function and replaces it with a `NavigationCallBacks` object.

**Why:**
Currently this package expects callers to provide a generic `navigationCallBack` function that will be called with a `NavigationAction` to get the hosting page to perform a navigation, for example to a login screen.

We also require the hosting page to provide a separate `disableChat` argument if they which to opt out of chat functonally.

The idea is that not all navigation scenarios need to be handled by all hosting pages. For example if a page has disabled chat, then they shouldn't need to handle the login navigation. Moving to the map of callbacks rather then a single function also allow us to tie functionally to the capabilities the hosting page provides, rather than asking them explicitly.

So, if a hosting page doesn't want to use chat, then they can just not provide the `login` navigation function. If they don't care about linking to a help page, they can just not provide the `help` navigation function. And when these functions aren't provided, GetSetUp can disable those capabilities on the iframed pages.