### PR TITLE
EP-923: Update iframe link template, Set allow-popups attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2023-08-21
+
+### Added
+
+- `linkTemplates.learnPage`: An option to pass in a URL template that will be used to construct links from one browse page to the learn page.
+
+- `linkTemplates.fitnessPage`: An option to pass in a URL template that will be used to construct links from one browse page to fitness page.
+
+- New sandbox attribute `allow-popups`: Allows popups (like from Window.open(), target="_blank", Window.showModalDialog()). This has been added to enable the 'add to calendar' functionality, which allows a user to open a new web page to book an upcoming class using their preferred calendar service.
+
 ## [1.5.0] - 2023-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ export interface CreateIframeOptions {
      * For example: `https://example.com/classes/{classSlug}/{sessionId}` could become `https://example.com/classes/cooking-with-rice/83bas8dfba`.
      */
     joinClass?: string
+    /**
+     * This template should be the URL of the learn page on your site.
+     * For example: `https://example.com/online-classes/learn/`.
+     */
+    learnPage?: string
+    /**
+     * This template should be the URL of the fitness page on your site.
+     * For example: `https://example.com/online-classes/fitness/`.
+     */
+    fitnessPage?: string
   }
 
   /**
@@ -168,7 +178,9 @@ export interface CreateIframeOptions {
 - `navigationCallBack` (REQUIRED): This is used to navigate between pages on the hosting site, from class listings to the page that embeds the video of the class. It is passed the `navigationAction` (`"learn" | "fitness" | "joinClass" | "login" | "home" | "help"`) and if the `navigationAction` is `"joinClass"` is is also passed the `sessionId` and `classSlug` of the class the user wants to join. The hosting site should deal with these navigation requests as appropriate.
 - `tokenRequestCallBack` (OPTIONAL): This callback is used to get a token from the hosting page. This token is used for chat authorization, so this callback is optional if you have disabled chat, otherwise this callback is required. This callback is called when the iframe loads or the current token expires. The callback must return An encrypted JWT (JWE) that was encrypted with the public key given to you by GetSetUp. That token maybe returned as a pain string, or as a string inside a promise if your token generation is async. If no token is available (E.g. the user is not logged into your site) you may return `null`, `undefined`, nothing (`void`) or a promise that resolves to any of those. Details on constructing the token are below in the [Token](#token) section.
 - `statusCallBack` (OPTIONAL): This callback is called when the iframe is loading, has loaded, or errors. The object that is passed to this function has a `status` and a `message`. Both of those fields are for intended to inform developers what the iframe is doing, they SHOULD NOT be shown to users.
-- `linkTemplates.joinClass` (OPTIONAL): A URL template that will be used to construct links from the embedded browse pages (learn, fitness) to the page that embeds the join class page. This is an optional convenience offered to premium partners, it doesn't effect the navigation between pages which is still handled by the `navigationCallBack`. Rather it provides link that bots can crawl to aid with SEO. See the [link templates section](#link-templates) for more information. `linkTemplates` is an object to allow for future expansion of this concept, but only the `joinClass` link template is currently supported.
+- `linkTemplates.joinClass` (OPTIONAL): A URL template that will be used to construct links from the embedded browse pages (learn, fitness) to the page that embeds the join class page. This is an optional convenience offered to premium partners, it doesn't effect the navigation between pages which is still handled by the `navigationCallBack`. Rather it provides a link that bots can crawl to aid with SEO. See the [link templates section](#link-templates) for more information. `linkTemplates` is an object to allow for future expansion of this concept.
+- `linkTemplates.learnPage` (OPTIONAL): A URL template that will be used to construct links from one embedded browse pages (ex. fitness) to the learn page. This is an optional convenience offered to premium partners, it doesn't effect the navigation between pages which is still handled by the `navigationCallBack`. Rather it provides a link that bots can crawl to aid with SEO. See the [link templates section](#link-templates) for more information.
+- `linkTemplates.fitnessPage` (OPTIONAL): A URL template that will be used to construct links from one embedded browse pages (ex. learn) to the fitness page. This is an optional convenience offered to premium partners, it doesn't effect the navigation between pages which is still handled by the `navigationCallBack`. Rather it provides a link that bots can crawl to aid with SEO. See the [link templates section](#link-templates) for more information.
 - `targetUrls` (OPTIONAL): Allow the caller to override the the urls of the pages to be embedded. Used for testing, this should not be required in production. Is an object of the form :
 ```js
 {
@@ -260,7 +272,7 @@ const token = new jose.EncryptJWT({})
 
 ### Link Template
 
-> `linkTemplates` is an object to allow for future expansion of this concept, but only the `joinClass` link template is currently supported.
+> `linkTemplates` is an object to allow for future expansion of this concept, but only the `joinClass`,  `learnPage`, and `fitnessPage` link templates are currently supported.
 
 The Link Template is an optional URL template passed into the `GSU.createIframe` function as a string. If present in the string, the tokens `{classSlug}` and `{sessionId}` are replaced with their values.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getsetup/embed",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@getsetup/embed",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@testing-library/dom": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsetup/embed",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -801,4 +801,28 @@ describe('GSU Embedded Shell', () => {
     // For backwards compatibility we also send the old device-id query string. This should be removed at some point.
     expect(gsuIframe).toHaveAttribute('src', expect.stringContaining('device-id=o980asd09uan89'))
   })
+
+  test('sends the linkTemplates query string if required', () => {
+    document.body.innerHTML = '<div id="gsuTarget"></div>'
+
+    createIframe({
+      targetElementId: 'gsuTarget',
+      targetPage: 'fitness',
+      navigationCallBack: mockNavCallback,
+      embeddingOrgId: 'AOL',
+      tokenRequestCallBack: mockTokenCallback,
+      linkTemplates: {joinClass: 'link-template-join-class', fitnessPage: '/fitness', learnPage: '/learn'},
+    })
+
+    const gsuTargetChildren = queryByAttribute('id', document.body, 'gsuTarget')?.children
+    expect(gsuTargetChildren).not.toBeNull()
+    expect(gsuTargetChildren).not.toBeUndefined()
+    expect(gsuTargetChildren!.length).toBe(1)
+
+    const gsuIframe = gsuTargetChildren![0]
+
+    expect(gsuIframe).toHaveAttribute('src', expect.stringContaining(`/fitness`))
+    expect(gsuIframe).toHaveAttribute('src', expect.stringContaining(`link-template-join-class`))
+
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,8 @@ export function createIframe({
   // We need:
   // * allow-scripts - so our js runs.
   // * allow-same-origin - otherwise our postMessage messages do not have an origin attached, and we would like to check the origin of messages.
-  gsuEmbeddedIframe.setAttribute('sandbox', 'allow-scripts allow-same-origin')
+  // * allow-popups - to allow links with target _blank attribute to work
+  gsuEmbeddedIframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-popups')
   gsuEmbeddedIframe.setAttribute('allow', 'fullscreen; autoplay;')
   gsuEmbeddedIframe.setAttribute('allowfullscreen', '') // To support Firefox and Safari.
   gsuEmbeddedIframe.setAttribute('scrolling', 'no')

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,16 @@ export interface CreateIframeOptions {
      * For example: `https://example.com/classes/{classSlug}/{sessionId}` could become `https://example.com/classes/cooking-with-rice/83bas8dfba`.
      */
     joinClass?: string
+    /**
+     * This template should be the URL of the learn page on your site.
+     * For example: `https://example.com/online-classes/learn/`.
+     */
+    learnPage?: string
+    /**
+     * This template should be the URL of the fitness page on your site.
+     * For example: `https://example.com/online-classes/fitness/`.
+     */
+    fitnessPage?: string
   }
 
   /** Optional - Allows the caller to override urls that will be loaded in the iframe. Used for testing. */
@@ -207,6 +217,13 @@ export function createIframe({
 
   // Pass the join class link template to allow the page to construct hosting site links for SEO.
   if (linkTemplates?.joinClass) iframeSrc.searchParams.append('link-template-join-class', linkTemplates?.joinClass)
+
+  // Pass the navigation path link template to allow the page to construct hosting site links for SEO.
+  if (linkTemplates?.learnPage) iframeSrc.searchParams.append('link-template-navigation-path', linkTemplates?.learnPage)
+
+  // Pass the navigation path link template to allow the page to construct hosting site links for SEO.
+  if (linkTemplates?.fitnessPage)
+    iframeSrc.searchParams.append('link-template-navigation-path', linkTemplates?.fitnessPage)
 
   const tellHostingPageIframeStatus = errorReporter({
     statusCallBack,


### PR DESCRIPTION
This adds:

1. `learnPage` and `fitnessPage`  options to the `linkTemplates` property, which is used to construct links inside the iframe that allows navigation between browse pages.

2. A new sandbox attribute `allow-popups`. This allows popups (like from `Window.open(), target="_blank"`, `Window.showModalDialog()`).