### PR TITLE
Add support for different embed back end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2023-10-02
+
+### Added
+
+- Experimental support for a different back end powering the embed experience.
+
 ## [1.6.0] - 2023-08-21
 
 ### Added
@@ -101,7 +107,7 @@ This means that the size of the joinClass iframe can be controlled by the elemen
 
 ### Fixed
 
-- The createIframe function now supports a fallback for browsers that don't support replaceChildren. See: https://caniuse.com/?search=replaceChildren.
+- The createIframe function now supports a fallback for browsers that don't support replaceChildren. See: <https://caniuse.com/?search=replaceChildren>.
 
 ## [1.0.1] - 2023-02-28
 

--- a/docs/opt-in-customization.md
+++ b/docs/opt-in-customization.md
@@ -1,0 +1,98 @@
+# Setup
+
+## Site layout
+
+For the example below we will assume a two page site. The first page will host the "discover" page that embeds a list of classes offered by GetSetUp.
+The second page is the "class" page that hosts the video viewing and chat experience.
+
+## How to install locally
+
+In your project, run `npm install @getsetup/embed`
+The next step is to import and configure the package on a couple of pages.
+
+### Browsing page
+
+First on a page where you want the class browsing experience create a div and setup the iframe:
+
+```html
+<div id="iframe-target"></div>
+```
+
+```ts
+import * as GSU from "@getsetup/embed";
+
+// This function is supplied by the hosting page.
+// We assume a simple navigation scheme, and we will ignore classSlug for now.
+// This function will be called by the GSU iframe when it needs to navigate.
+const navigationCallBack = (
+  navigationAction: GSU.NavigationAction,
+  sessionId?: string,
+  classSlug?: string
+) => {
+  const url = new URL(window.location.href);
+  targetUrl.pathname = `/hostSitePath/${navigationAction}`
+
+  // The 'class' navigation action is special because we need to pass the class slug to the 'class' page.
+  if (navigationAction === "class" && classSlug) {
+    // const url = new URL(window.location.href)
+    url.searchParams.set("class-slug", classSlug);
+  }
+  window.location.assign(url);
+};
+
+GSU.createIframe({
+  targetElementId: "iframe-target",
+  targetPage: "discover",
+  embeddingOrgId: "searchandnews",
+  navigationCallBack,
+});
+```
+
+The content of the div will be replaced with the GetSetUp iframe.
+
+### Class page
+
+Then on a second page where you want the user to watch the class:
+
+```html
+<div id="iframe-target"></div>
+```
+
+```ts
+import * as GSU from "@getsetup/embed";
+
+// This function is supplied by the hosting page.
+// We assume a simple navigation scheme, and we will ignore classSlug for now.
+// This function will be called by the GSU iframe when it needs to navigate.
+const navigationCallBack = (
+  navigationAction: GSU.NavigationAction,
+  sessionId?: string,
+  classSlug?: string
+) => {
+  const url = new URL(window.location.href);
+  targetUrl.pathname = `/hostSitePath/${navigationAction}`
+
+  // The 'class' navigation action is special because we need to pass the class slug to the 'class' page.
+  if (navigationAction === "class" && classSlug) {
+    // const url = new URL(window.location.href)
+    url.searchParams.set("class-slug", classSlug);
+  }
+  window.location.assign(url);
+};
+
+//Get the class slug from the query string.
+const urlParams = new URLSearchParams(window.location.search);
+const classSlug = urlParams.get("class-slug");
+
+GSU.createIframe({
+  targetElementId: "iframe-target",
+  targetPage: "class",
+  embeddingOrgId: "searchandnews",
+  classSlug: classSlug 
+  navigationCallBack,
+});
+```
+
+## Use the site
+
+Now that both pages are setup, you can go to the page hosting the "discover" page and click on a class. The iframe will request that the hosting page navigates to the "class" page using the `navigationCallBack` we setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getsetup/embed",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@getsetup/embed",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@testing-library/dom": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsetup/embed",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const targetPageUrls = {
   learn: 'https://embed.getsetup.io/embedded/{embeddingOrgId}/learn',
   fitness: 'https://embed.getsetup.io/embedded/{embeddingOrgId}/fitness',
   joinClass: 'https://lobby-embed.getsetup.io/session/{sessionId}',
-  discover: 'http://embed.getsetuplive.com/{embeddingOrgId}',
+  discover: 'https://embed.getsetuplive.com/{embeddingOrgId}',
   class: 'https://embed.getsetuplive.com/class/{embeddingOrgId}/?classTitle={classTitle}',
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export interface CreateIframeOptions {
   }
 
   /** Optional - Allows the caller to override urls that will be loaded in the iframe. Used for testing. */
-  targetUrls?: typeof targetPageUrls
+  targetUrls?: Partial<typeof targetPageUrls>
 
   /**
    * Optional - Allows the caller to override the loading timeout that displays an error message if the iframe doesn't load in time.
@@ -191,7 +191,7 @@ export function createIframe({
     throw new Error('The targetPage should be one of "learn" | "fitness" | "joinClass" | "discover" | "class".')
   }
 
-  const targetPages = targetUrls ?? targetPageUrls
+  const targetPages = { ...targetPageUrls, ...targetUrls }
   const normalisedOrgId = embeddingOrgId.toLowerCase()
   targetPages.learn = targetPages.learn.replace('{embeddingOrgId}', normalisedOrgId)
   targetPages.fitness = targetPages.fitness.replace('{embeddingOrgId}', normalisedOrgId)

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,10 @@ export function createIframe({
   targetPages.learn = targetPages.learn.replace('{embeddingOrgId}', normalisedOrgId)
   targetPages.fitness = targetPages.fitness.replace('{embeddingOrgId}', normalisedOrgId)
   targetPages.joinClass = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
-  targetPages.class = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
-  targetPages.discover = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
+  targetPages.class = targetPages.class
+    .replace('{embeddingOrgId}', normalisedOrgId)
+    .replace('{classTitle}', classSlug ?? '')
+  targetPages.discover = targetPages.discover.replace('{embeddingOrgId}', normalisedOrgId)
   if (sessionId) {
     targetPages.joinClass = targetPages.joinClass.replace('{sessionId}', sessionId)
   }
@@ -273,15 +275,19 @@ export function createIframe({
   const loadingTimeout = setTimeout(handleTimeout, loadingTimeoutThreshold)
 
   // Try to load the head so we know if the page is working.
-
-  fetch(iframeSrc, { method: 'HEAD', mode: 'cors' })
-    .then((response) => {
-      if (!response.ok) handleNotLoading('HEAD Response was not ok.')
-    })
-    .catch((error) => {
-      const errorMessage = error.message ?? error
-      handleNotLoading(`HEAD Response errored. ${errorMessage}`)
-    })
+  if (targetPage === 'class' || targetPage === 'discover') {
+    //Skip the pre-check and loading check because the strapi backend doesn't support it.
+    hasLoadedSuccessfully = true
+  } else {
+    fetch(iframeSrc, { method: 'HEAD', mode: 'cors' })
+      .then((response) => {
+        if (!response.ok) handleNotLoading('HEAD Response was not ok.')
+      })
+      .catch((error) => {
+        const errorMessage = error.message ?? error
+        handleNotLoading(`HEAD Response errored. ${errorMessage}`)
+      })
+  }
 
   // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox for info about sandboxing iframes.
   // We need:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ const targetPageUrls = {
   learn: 'https://embed.getsetup.io/embedded/{embeddingOrgId}/learn',
   fitness: 'https://embed.getsetup.io/embedded/{embeddingOrgId}/fitness',
   joinClass: 'https://lobby-embed.getsetup.io/session/{sessionId}',
+  discover: 'http://embed.getsetuplive.com/{embeddingOrgId}',
+  class: 'https://embed.getsetuplive.com/class/{embeddingOrgId}/?classTitle={classTitle}',
 }
 
 const navigationActions = {
@@ -43,6 +45,8 @@ export interface CreateIframeOptions {
 
   /** The id of the class session to play. Required if the `targetPage` is `joinClass`. */
   sessionId?: string
+
+  classSlug?: string
 
   /** The id of your organisation as issued to you by GetSetUp. */
   embeddingOrgId: string
@@ -173,12 +177,18 @@ export function createIframe({
   loadingTimeoutInMs,
   themeOptions,
   analyticsInfo,
+  classSlug,
 }: CreateIframeOptions): IframeInstance {
   if (targetPage == 'joinClass' && !sessionId) {
     throw new Error('sessionId is required if you are loading a join class page.')
   }
+
+  if (targetPage == 'class' && !classSlug) {
+    throw new Error('classSlug is required if you are loading a class page.')
+  }
+
   if (!Object.keys(targetPageUrls).includes(targetPage)) {
-    throw new Error('The targetPage should be one of "learn" | "fitness" | "joinClass".')
+    throw new Error('The targetPage should be one of "learn" | "fitness" | "joinClass" | "discover" | "class".')
   }
 
   const targetPages = targetUrls ?? targetPageUrls
@@ -186,6 +196,8 @@ export function createIframe({
   targetPages.learn = targetPages.learn.replace('{embeddingOrgId}', normalisedOrgId)
   targetPages.fitness = targetPages.fitness.replace('{embeddingOrgId}', normalisedOrgId)
   targetPages.joinClass = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
+  targetPages.class = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
+  targetPages.discover = targetPages.joinClass.replace('{embeddingOrgId}', normalisedOrgId)
   if (sessionId) {
     targetPages.joinClass = targetPages.joinClass.replace('{sessionId}', sessionId)
   }


### PR DESCRIPTION
This adds support for a different back end that powers the embed experience. Callers can opt into this buy contacting GSU (as it is enabled on a case by case basis at the moment) and using `discover` and `class` as `targetPage`s in the iframe options.